### PR TITLE
sshforwarding: exit on ssh errors without printing any further errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,27 +1,13 @@
-use base64::DecodeError;
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("io operation error.")]
-    IoError(#[from] std::io::Error),
-
-    #[error("Json serialization error.")]
-    JsonError(#[from] serde_json::Error),
-
-    #[error("Failed to decode base64 content of OpenSSH key.")]
-    DecodeError(#[from] DecodeError),
+    #[error("{0}")]
+    IO(#[from] std::io::Error),
 
     #[error("SSH forwarding network tunnel exit with non-zero exit code {0}")]
     TunnelExitNonZero(String),
 
-    #[error("network tunnel requested, but no destination address was found in the endpoint configuration")]
-    MissingDestinationAddress,
-
-    #[error("malformed destination address {0}")]
-    BadDestinationAddress(String),
-
-    // Used to silently terminate the SSH tunnel without logging any further errors
+    // Used to bubble up SSH tunnel errors without logging any further errors
     // this allows the last `ssh: ` log to be reported as the main error to the user
-    #[error("")]
-    SilentError
+    #[error("{0}")]
+    SSH(String)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,4 +19,9 @@ pub enum Error {
 
     #[error("malformed destination address {0}")]
     BadDestinationAddress(String),
+
+    // Used to silently terminate the SSH tunnel without logging any further errors
+    // this allows the last `ssh: ` log to be reported as the main error to the user
+    #[error("")]
+    SilentError
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,7 @@ async fn main() -> io::Result<()> {
     init_logging(&log_args);
 
     if let Err(err) = run(command).await.as_ref() {
-        if !matches!(err, Error::SilentError) {
-            tracing::error!(error = ?err, "network tunnel failed.");
-        }
+        tracing::error!(error = %err, "network tunnel failed.");
         std::process::exit(1);
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,19 +62,17 @@ async fn main() -> io::Result<()> {
 
 async fn run_and_cleanup(tunnel: &mut Box<dyn NetworkTunnel>) -> Result<(), Error> {
     let tunnel_block = {
-        let prep = tunnel.prepare().await;
+        tunnel.prepare().await?;
 
-        future::ready(prep).and_then(|()| {
-            // Write "READY" to stdio to unblock Go logic.
-            // The current workflow assumes that
-            //   1. After tunnel.prepare() is called, the network tunnel is able to accept requests from clients without sending errors back to clients.
-            //   2. The network tunnel is able to process client requests immediately after `tunnel.start_serve` is called.
-            // If either of the assumptions is invalid for any new tunnel type, the READY-logic need to be moved to a separate task, which
-            //    sends out the "READY" signal after making sure the network tunnel is started and working properly.
-            println!("READY");
+        // Write "READY" to stdio to unblock Go logic.
+        // The current workflow assumes that
+        //   1. After tunnel.prepare() is called, the network tunnel is able to accept requests from clients without sending errors back to clients.
+        //   2. The network tunnel is able to process client requests immediately after `tunnel.start_serve` is called.
+        // If either of the assumptions is invalid for any new tunnel type, the READY-logic need to be moved to a separate task, which
+        //    sends out the "READY" signal after making sure the network tunnel is started and working properly.
+        println!("READY");
 
-            tunnel.start_serve()
-        }).await
+        tunnel.start_serve().await
     };
 
     // We must make sure we cleanup the child process. This is specially important

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,9 @@ async fn main() -> io::Result<()> {
     init_logging(&log_args);
 
     if let Err(err) = run(command).await.as_ref() {
-        tracing::error!(error = ?err, "network tunnel failed.");
+        if !matches!(err, Error::SilentError) {
+            tracing::error!(error = ?err, "network tunnel failed.");
+        }
         std::process::exit(1);
     }
     Ok(())
@@ -64,15 +66,15 @@ async fn run_and_cleanup(tunnel: &mut Box<dyn NetworkTunnel>) -> Result<(), Erro
     let tunnel_block = {
         let prep = tunnel.prepare().await;
 
-        // Write "READY" to stdio to unblock Go logic.
-        // The current workflow assumes that
-        //   1. After tunnel.prepare() is called, the network tunnel is able to accept requests from clients without sending errors back to clients.
-        //   2. The network tunnel is able to process client requests immediately after `tunnel.start_serve` is called.
-        // If either of the assumptions is invalid for any new tunnel type, the READY-logic need to be moved to a separate task, which
-        //    sends out the "READY" signal after making sure the network tunnel is started and working properly.
-        println!("READY");
-
         future::ready(prep).and_then(|()| {
+            // Write "READY" to stdio to unblock Go logic.
+            // The current workflow assumes that
+            //   1. After tunnel.prepare() is called, the network tunnel is able to accept requests from clients without sending errors back to clients.
+            //   2. The network tunnel is able to process client requests immediately after `tunnel.start_serve` is called.
+            // If either of the assumptions is invalid for any new tunnel type, the READY-logic need to be moved to a separate task, which
+            //    sends out the "READY" signal after making sure the network tunnel is started and working properly.
+            println!("READY");
+
             tunnel.start_serve()
         }).await
     };

--- a/src/sshforwarding.rs
+++ b/src/sshforwarding.rs
@@ -114,17 +114,13 @@ impl NetworkTunnel for SshForwarding {
             } else if line.starts_with("Warning: Permanently added") {
                 tracing::debug!("{}", &line);
             } else if line.contains("Permission denied") {
-                tracing::error!("{}", &line);
-                return Err(Error::SilentError)
+                return Err(Error::SSH(line));
             } else if line.contains("Network is unreachable") {
-                tracing::error!("{}", &line);
-                return Err(Error::SilentError)
+                return Err(Error::SSH(line));
             } else if line.contains("Connection timed out") {
-                tracing::error!("{}", &line);
-                return Err(Error::SilentError)
+                return Err(Error::SSH(line));
             } else if line.contains("Operation timed out") {
-                tracing::error!("n{}", &line);
-                return Err(Error::SilentError)
+                return Err(Error::SSH(line));
             } else {
                 tracing::info!("ssh: {}", &line);
             }

--- a/src/sshforwarding.rs
+++ b/src/sshforwarding.rs
@@ -112,13 +112,19 @@ impl NetworkTunnel for SshForwarding {
             if line.starts_with("debug1:") {
                 tracing::debug!("ssh: {}", &line);
             } else if line.starts_with("Warning: Permanently added") {
-                tracing::debug!("ssh: {}", &line);
+                tracing::debug!("{}", &line);
             } else if line.contains("Permission denied") {
-                tracing::error!("ssh: {}", &line);
+                tracing::error!("{}", &line);
+                return Err(Error::SilentError)
             } else if line.contains("Network is unreachable") {
-                tracing::error!("ssh: {}", &line);
+                tracing::error!("{}", &line);
+                return Err(Error::SilentError)
             } else if line.contains("Connection timed out") {
-                tracing::error!("ssh: {}", &line);
+                tracing::error!("{}", &line);
+                return Err(Error::SilentError)
+            } else if line.contains("Operation timed out") {
+                tracing::error!("n{}", &line);
+                return Err(Error::SilentError)
             } else {
                 tracing::info!("ssh: {}", &line);
             }


### PR DESCRIPTION
This will allow us to give the SSH client's error directly to the user as the last error.

Example output:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d9b58484-ec45-40ae-b6e1-b482340a559a">


