### PR TITLE
error on "Connection refused" during initialization

### DIFF
--- a/src/sshforwarding.rs
+++ b/src/sshforwarding.rs
@@ -137,6 +137,8 @@ impl NetworkTunnel for SshForwarding {
                 return Err(Error::SSH(line));
             } else if line.contains("Operation timed out") {
                 return Err(Error::SSH(line));
+            } else if line.contains("Connection refused") {
+                return Err(Error::SSH(line));
             } else {
                 tracing::info!("ssh: {}", &line);
             }


### PR DESCRIPTION
This is potential error that can be received from the server, and if we get it we should fail to start the tunnel outright rather than starting it and then immediately failing.