### PR TITLE
log final error message as a single string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ async fn main() -> io::Result<()> {
     init_logging(&log_args);
 
     if let Err(err) = run(command).await.as_ref() {
-        tracing::error!(error = %err, "network tunnel failed.");
+        tracing::error!("network tunnel failed: {}", err);
         std::process::exit(1);
     }
     Ok(())


### PR DESCRIPTION
For interactive workflows the UI shows the final log from the connector as the error, and specifically for Discover it will show the "message" part of the log in the UI prominently.

Prior to this change, that would just be the "network-tunnel failed." part, even though there was more information in the structured log.

This modifies the log output to include the actual error message in the message.